### PR TITLE
Adding a minimum height option

### DIFF
--- a/dist/jquery.matchHeight.js
+++ b/dist/jquery.matchHeight.js
@@ -82,7 +82,8 @@
             byRow: true,
             property: 'height',
             target: null,
-            remove: false
+            remove: false,
+            minHeight: 0
         };
 
         if (typeof options === 'object') {
@@ -276,6 +277,12 @@
                 if ($that.css('box-sizing') !== 'border-box') {
                     verticalPadding += _parse($that.css('border-top-width')) + _parse($that.css('border-bottom-width'));
                     verticalPadding += _parse($that.css('padding-top')) + _parse($that.css('padding-bottom'));
+                }
+
+                // set height to minimum height, if less than element
+                if ( targetHeight < opts.minHeight )
+                {
+                    targetHeight = opts.minHeight;
                 }
 
                 // set the height (accounting for padding and border)


### PR DESCRIPTION
I have a bunch of elements I want to match in height, but I always want them to be at least a certain height. Now I can pass a min-height and ensure they'll be at least that tall.